### PR TITLE
Allow to select trigger notifications for a single element

### DIFF
--- a/background.js
+++ b/background.js
@@ -37,9 +37,19 @@ chrome.runtime.onMessage.addListener(function(request, sender) {
   }
 });
 
+chrome.commands.onCommand.addListener(function (command) {
+  switch (command) {
+    case 'toggle':
+      chrome.tabs.query({active: true, currentWindow: true}, function(tabs){
+        chrome.tabs.sendMessage(tabs[0].id, { type: 'toggle' });
+      });
+      break;
+  }
+});
+
 chrome.notifications.onClicked.addListener(function callback(notificationId) {
   var updateProperties = { 'active': true };
   chrome.tabs.update(notificationTab[notificationId], updateProperties);
   chrome.notifications.clear(notificationId);
-  window.focs();
+  window.focus();
 });

--- a/background.js
+++ b/background.js
@@ -1,27 +1,4 @@
-const id = 'domification-menu';
-
-chrome.contextMenus.create({title: 'Domification - Toggle observe tab changes', id: id}, function() {
-  if (chrome.extension.lastError) {
-    console.log('Got expected error: ' + chrome.extension.lastError.message);
-    }
-});
-
-chrome.contextMenus.onClicked.addListener(function (obj) {
-  if (obj.menuItemId !== id) return;
-  chrome.tabs.executeScript({
-    file: 'content.js'
-  });
-  const notId = 'start' + Math.random();
-  chrome.notifications.create(notId, {
-    type: 'basic',
-    title: 'Started tracking changed in this tab',
-    message: '',
-    iconUrl: chrome.extension.getURL('icon.png'),
-  });
-});
-
 const notificationTab = {};
-
 
 chrome.runtime.onMessage.addListener(function(request, sender) {
   console.log(sender)

--- a/content.js
+++ b/content.js
@@ -1,5 +1,0 @@
-var observer = new MutationObserver(function(mutations) {
-  chrome.runtime.sendMessage({ type: 'notification' });
-});
-
-observer.observe(document.body, { childList: true, subtree: true, characterData: true });

--- a/core.css
+++ b/core.css
@@ -1,0 +1,8 @@
+.crx_mouse_visited {
+  background-color: #bcd5eb !important;
+  outline: 1px solid #5166bb !important;
+}
+
+.elm_changed {
+  background-color: red !important;
+}

--- a/core.js
+++ b/core.js
@@ -44,9 +44,15 @@ var selectFunc = function (e) {
   targetElem = e.srcElement;
   observer = new MutationObserver(function() {
     chrome.runtime.sendMessage({ type: 'notification', element: targetElem });
+
+    // Disconnect the observer temporarily so we can set the class name
+    // to avoid triggering and endless loop.
+    observer.disconnect();
     targetElem.classList.add(ELEMENT_CHANGED_CLASSNAME);
+    observer.observe(targetElem, { childList: true, subtree: true, characterData: true, attributes: true });
+
   });
-  observer.observe(targetElem, { childList: true, subtree: true, characterData: true });
+  observer.observe(targetElem, { childList: true, subtree: true, characterData: true, attributes: true });
 
 }
 

--- a/core.js
+++ b/core.js
@@ -1,0 +1,81 @@
+// Unique ID for the className.
+const MOUSE_VISITED_CLASSNAME = 'crx_mouse_visited';
+const ELEMENT_CHANGED_CLASSNAME = 'elm_changed';
+
+let enabled = false;
+let observer, targetElem;
+
+// Previous dom, that we want to track, so we can remove the previous styling.
+var prevDOM = null;
+
+// Highlights the DOM element when the mouse moves
+var highlightFunc = function (e) {
+  var srcElement = e.srcElement;
+
+    // For NPE checking, we check safely. We need to remove the class name
+    // Since we will be styling the new one after.
+    if (prevDOM != null) {
+      prevDOM.classList.remove(MOUSE_VISITED_CLASSNAME);
+    }
+
+    // Add a visited class name to the element. So we can style it.
+    srcElement.classList.add(MOUSE_VISITED_CLASSNAME);
+
+    // The current element is now the previous. So we can remove the class
+    // during the next iteration.
+    prevDOM = srcElement;
+}
+
+// Whenever the user clicks something, create an observer that will
+// notify background so the notification can be triggered.
+var selectFunc = function (e) {
+  // Don't perform the default action on the element.
+  e.preventDefault();
+
+  // After selecting the elemtn, disable the extension.
+  removeListeners();
+  enabled = false;
+  // Only 1 observer supported to start.
+  if (observer) {
+    observer.disconnect();
+    targetElem.classList.remove(ELEMENT_CHANGED_CLASSNAME);
+  }
+
+  targetElem = e.srcElement;
+  observer = new MutationObserver(function() {
+    chrome.runtime.sendMessage({ type: 'notification', element: targetElem });
+    targetElem.classList.add(ELEMENT_CHANGED_CLASSNAME);
+  });
+  observer.observe(targetElem, { childList: true, subtree: true, characterData: true });
+
+}
+
+var addListeners = function() {
+  document.addEventListener('mousemove', highlightFunc, false);
+  document.addEventListener('click', selectFunc, false);
+}
+
+var removeListeners = function() {
+  document.removeEventListener('mousemove', highlightFunc, false);
+  document.removeEventListener('click', selectFunc, false);
+  if (prevDOM != null) {
+    prevDOM.classList.remove(MOUSE_VISITED_CLASSNAME);
+  }
+}
+
+// Every time we get a new message toggle the plugin
+chrome.runtime.onMessage.addListener(function(request) {
+  if (request.type == 'toggle') {
+    // Remove any previous observers listeners if there are any;
+    if (observer) {
+      observer.disconnect();
+      targetElem.classList.remove(ELEMENT_CHANGED_CLASSNAME);
+    }
+    if (enabled) {
+      removeListeners();
+    } else {
+      addListeners();
+    }
+    enabled = !enabled;
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -11,13 +11,31 @@
     "chrome://favicon/"
   ],
   "content_security_policy": "script-src 'self'; object-src 'self'; img-src chrome://favicon/;",
+  "commands": {
+    "toggle": {
+      "description": "Activate extension",
+      "suggested_key": {
+        "default": "Alt+A",
+        "mac": "Command+A"
+      }
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://*/*","http://*/*"],
+      "css": ["core.css"],
+      "js": ["core.js"],
+      "run_at": "document_end",
+      "all_frames": true
+    }
+  ],
   "background": {
     "persistent": false,
     "scripts": ["background.js"]
-    },    
-"icons": {
-  "16": "icon.png",
-  "38": "icon.png",
-  "48": "icon.png"
-}
+  },
+  "icons": {
+    "16": "icon.png",
+    "38": "icon.png",
+    "48": "icon.png"
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,6 @@
   "manifest_version": 2,
   "permissions": [
     "activeTab",
-    "contextMenus",
     "notifications",
     "tabs",
     "chrome://favicon/"


### PR DESCRIPTION
This commit allows to select a specific element from the DOM and trigger
notifications when that element changes only

Also, by default the extension is disabled unless the user triggers the
default shortcut to toggle it on/off

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>