### PR TITLE
Make the extension highlight the last present parent if the target element is removed

### DIFF
--- a/core.css
+++ b/core.css
@@ -4,5 +4,9 @@
 }
 
 .elm_changed {
-  background-color: red !important;
+  border: medium dashed red !important;
+}
+
+.deleted-nav {
+  /*position: fixed;*/
 }


### PR DESCRIPTION
This PR handles the case where the target element is removed from the DOM and traverses their parents until the first present is found and then applies the styling to that one